### PR TITLE
Fix cam mode attack sound suppression

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mutplayer/ProtocolLibHook.java
+++ b/src/main/java/de/elia/cameraplugin/mutplayer/ProtocolLibHook.java
@@ -39,7 +39,11 @@ public class ProtocolLibHook {
                                 packet.getIntegers().read(2) / 8.0,
                                 event.getPlayer().getWorld());
 
-                        if (emitter != null && soundsDisabled.contains(emitter.getUniqueId())) {
+                        boolean receiverInCam = soundsDisabled.contains(event.getPlayer().getUniqueId());
+
+                        if (emitter != null &&
+                                (soundsDisabled.contains(emitter.getUniqueId()) || receiverInCam) &&
+                                !event.getPlayer().getUniqueId().equals(emitter.getUniqueId())) {
                             event.setCancelled(true);
                         }
                     }
@@ -61,7 +65,8 @@ public class ProtocolLibHook {
                             break;
                         }
                     }
-                    if (emitter == null || !soundsDisabled.contains(emitter.getUniqueId())) return;
+                    if (emitter == null || !soundsDisabled.contains(emitter.getUniqueId()) ||
+                            event.getPlayer().getUniqueId().equals(emitter.getUniqueId())) return;
 
                     var values = new java.util.ArrayList<com.comphenix.protocol.wrappers.WrappedDataValue>();
                     for (var value : event.getPacket().getDataValueCollectionModifier().read(0)) {


### PR DESCRIPTION
## Summary
- ensure attacks are inaudible to or from players in camera mode

## Testing
- `mvn -q test` *(fails: Failed to read artifact descriptor for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6871ff27ecc483228ec05dd43e290365