### PR TITLE
Add configurable camera particles

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -39,6 +39,9 @@ armorstand.damage-ignore-armor: true
 mute_attack: false
 mute_footsteps: false
 hide_sprint_particles: true
+camera-particles:
+  height: 1.0
+  particles-per-tick: 5
 
 log-colors:
   protocol-found: "GREEN"


### PR DESCRIPTION
## Summary
- allow configuring camera particles via `camera-particles` section
- spawn particles above the player while in camera mode
- stop particle effects on exit and plugin disable

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872f84c801c8322ac426c317f163bee