### PR TITLE
Fix camera team exit

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
@@ -312,6 +312,9 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         mutedPlayers.remove(player.getUniqueId());
         updateViewerTeam(player);
 
+        // Safety check to ensure the player really left the no-collision team
+        removePlayerFromNoCollisionTeam(player);
+
         // Aufräumen
         armorStandOwners.remove(armorStand.getUniqueId());
         hitboxEntities.remove(hitbox.getUniqueId());


### PR DESCRIPTION
## Summary
- ensure players are always removed from the `cam_no_push` team when exiting camera mode

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873177f90808322a600f9ddfec87126