### PR TITLE
Add configurable duration for exit action bar

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,12 @@ messages:
   reload-start: "&ePlugin wird neugestartet..."
   reload-success: "&aPlugin Reload erfolgreich."
   reload-exit: "&cKamera-Modus beendet aufgrund des Plugin Neustarts."
+  actionbar-on: "&aCam-Modus aktiviert"
+  actionbar-off: "&cCam-Modus beendet"
+
+action-bar:
+  enabled: true
+  off-duration: 60
 
 camera-mode:
   max-distance-enabled: true


### PR DESCRIPTION
## Summary
- make duration of camera mode exit message configurable
- cancel existing action bar tasks before starting a new one
- show action bar text after camera mode exit for configured time
- update `config.yml` with `action-bar.off-duration`
- fix exit message not showing by sending once and clearing later

## Testing
- `mvn -q -DskipTests package` *(fails: plugin resolution from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873251735f08322b1744e4e49023018