### PR TITLE
Fix lingering burn effect in camera fire guard

### DIFF
--- a/src/main/java/de/elia/cameraplugin/feuer/CamFireGuard.java
+++ b/src/main/java/de/elia/cameraplugin/feuer/CamFireGuard.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
+import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -162,6 +163,16 @@ public class CamFireGuard implements Listener {
         Material to = event.getNewState().getType();
         if (to == Material.FIRE || to == Material.SOUL_FIRE) {
             Bukkit.getScheduler().runTask(plugin, () -> hideFireForBlock(block));
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityCombust(EntityCombustEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            if (tasks.containsKey(player.getUniqueId())) {
+                event.setCancelled(true);
+                player.setFireTicks(0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- stop players from combusting while camera fire guard is active

## Testing
- `mvn -q -DskipTests install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873dd0243a48322b0217611fa7d9943