### PR TITLE
Add configurable chat notifications

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CamCommand.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CamCommand.java
@@ -16,32 +16,32 @@ public class CamCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(plugin.getMessage("no-player"));
+            plugin.sendConfiguredMessage(sender, "no-player");
             return true;
         }
 
         if (!player.hasPermission("camplugin.use")) {
-            player.sendMessage(plugin.getMessage("no-permission"));
+            plugin.sendConfiguredMessage(player, "no-permission");
             return true;
         }
 
         if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
             if (!player.isOp()) {
-                player.sendMessage(plugin.getMessage("no-permission"));
+                plugin.sendConfiguredMessage(player, "no-permission");
                 return true;
             }
-            player.sendMessage(plugin.getMessage("reload-start"));
+            plugin.sendConfiguredMessage(player, "reload-start");
             plugin.reloadPlugin(player);
-            player.sendMessage(plugin.getMessage("reload-success"));
+            plugin.sendConfiguredMessage(player, "reload-success");
             return true;
         }
 
         if (plugin.isInCameraMode(player)) {
             plugin.exitCameraMode(player);
-            player.sendMessage(plugin.getMessage("camera-off"));
+            plugin.sendConfiguredMessage(player, "camera-off");
         } else {
             plugin.enterCameraMode(player);
-            player.sendMessage(plugin.getMessage("camera-on"));
+            plugin.sendConfiguredMessage(player, "camera-on");
         }
         return true;
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,11 +8,14 @@ messages:
   body-env-damage: "&cDein Körper wurde durch {cause} verletzt! Kamera-Modus beendet."
   body-moved: "&cDein Körper wurde bewegt! Kamera-Modus beendet."
   body-got-effect: "&cDein Körper wurde von einem Effekt getroffen und der Kameramodus wurde beendet!"
+  body-suffocating: "&cDein Körper steckt fest und erstickt! Kamera-Modus beendet."
+  body-drowning: "&cDein Körper ertrinkt! Kamera-Modus beendet."
   cant-fly-in-lava: "&cDu kannst nicht durch Lava fliegen! Kamera-Modus wird beendet."
   cant-interact-other: "&cDu kannst mit dem Körper eines anderen Spielers nicht interagieren!"
   protocol-found: "ProtocolLib gefunden! Sound-Unterdrückung ist aktiviert."
   protocol-not-found: "ProtocolLib wurde nicht gefunden. Die Sound-Unterdrückung ist deaktiviert."
   cant-attack-other-body: "&cDu kannst im Kameramodus keine anderen Körper angreifen."
+  no-projectiles: "&cIm Kameramodus kannst du keine Projektile abschießen."
   armorstand.name-format: "&e{player}'s Körper"
   hitbox.name-format: "&c[HITBOX] {player}"
   reload-start: "&ePlugin wird neugestartet..."
@@ -20,6 +23,33 @@ messages:
   reload-exit: "&cKamera-Modus beendet aufgrund des Plugin Neustarts."
   actionbar-on: "&aCam-Modus aktiviert"
   actionbar-off: "&cCam-Modus beendet"
+
+message-settings:
+  enabled: true
+  camera-on: true
+  camera-off: true
+  no-permission: true
+  no-player: true
+  distance-limit: true
+  body-attacked: true
+  body-env-damage: true
+  body-moved: true
+  body-got-effect: true
+  body-suffocating: true
+  body-drowning: true
+  cant-fly-in-lava: true
+  cant-interact-other: true
+  protocol-found: true
+  protocol-not-found: true
+  cant-attack-other-body: true
+  no-projectiles: true
+  armorstand.name-format: true
+  hitbox.name-format: true
+  reload-start: true
+  reload-success: true
+  reload-exit: true
+  actionbar-on: true
+  actionbar-off: true
 
 action-bar:
   enabled: true


### PR DESCRIPTION
## Summary
- add `message-settings` section to config with global and per-message toggles
- add missing message texts
- provide API in `CameraPlugin` to check settings and send messages
- respect new settings in commands and events

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873fbf5498883228bc96e2d19e7e830