### PR TITLE
Fix ProtocolLib log message formatting

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
@@ -117,7 +117,7 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
                 if (protocolFoundLogColor != null) {
                     pfMessage = protocolFoundLogColor + pfMessage + ChatColor.RESET;
                 }
-                getLogger().info(pfMessage);
+                getLogger().info(ChatColor.stripColor(pfMessage));
             }
         }
         setupNoCollisionTeam();
@@ -1032,7 +1032,11 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
             if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
                 protocolLibAvailable = true;
                 new ProtocolLibHook(this, mutedPlayers, muteAttack, muteFootsteps, hideSprintParticles);
-                getLogger().info(getMessage("protocol-found"));
+                String pfMessage = getMessage("protocol-found");
+                if (protocolFoundLogColor != null) {
+                    pfMessage = protocolFoundLogColor + pfMessage + ChatColor.RESET;
+                }
+                getLogger().info(ChatColor.stripColor(pfMessage));
             }
         }
         setupNoCollisionTeam();


### PR DESCRIPTION
## Summary
- remove color codes when logging that ProtocolLib was found

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_68742a227f448322aa08bffed88aeefd