### PR TITLE
Implement cam mode safety delay

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CamCommand.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CamCommand.java
@@ -49,6 +49,9 @@ public class CamCommand implements CommandExecutor {
                 }
                 return true;
             }
+            if (!plugin.checkCamSafety(player)) {
+                return true;
+            }
             plugin.enterCameraMode(player);
             plugin.sendConfiguredMessage(player, "camera-on");
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -100,4 +100,8 @@ fireguard:
   tick-interval: 10
   radius-horizontal: 1.5
   radius-up: 2
-  radius-down: 1
+radius-down: 1
+
+camSafetyEnabled: true
+camSafetyDelay: 5
+camSafetyMessage: "§cDu kannst den Cam-Modus nicht starten! Du musst noch %seconds% Sekunden in Sicherheit bleiben."


### PR DESCRIPTION
## Summary
- add configurable safety delay before enabling cam mode
- store last damage timestamps for players
- prevent entering cam mode if recently damaged
- add config options `camSafetyEnabled`, `camSafetyDelay`, and `camSafetyMessage`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687487a09b988322b596a0634e0c8a8e