### PR TITLE
Organize config sections

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
@@ -1021,9 +1021,9 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         armorStandNameVisible = getConfig().getBoolean("armorstand.name-visible", true);
         armorStandVisible = getConfig().getBoolean("armorstand.visible", true);
         armorStandGravity = getConfig().getBoolean("armorstand.gravity", true);
-        muteAttack = getConfig().getBoolean("mute_attack", false);
-        muteFootsteps = getConfig().getBoolean("mute_footsteps", false);
-        hideSprintParticles = getConfig().getBoolean("hide_sprint_particles", true);
+        muteAttack = getConfig().getBoolean("mute.attack", false);
+        muteFootsteps = getConfig().getBoolean("mute.footsteps", false);
+        hideSprintParticles = getConfig().getBoolean("mute.hide-sprint-particles", true);
         particleHeight = getConfig().getDouble("camera-particles.height", 1.0);
         particlesPerTick = getConfig().getInt("camera-particles.particles-per-tick", 5);
         showOwnParticles = getConfig().getBoolean("camera-particles.show-own-particles", false);
@@ -1046,9 +1046,9 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         bossbarText = ChatColor.translateAlternateColorCodes('&', getConfig().getString("messages.bossbar-text", "Cam-Modus endet in: %time%"));
         cooldownText = ChatColor.translateAlternateColorCodes('&', getConfig().getString("messages.cooldown-text", "Du kannst den Cam-Modus erst in %time% erneut starten."));
         cooldownAvailableText = ChatColor.translateAlternateColorCodes('&', getConfig().getString("messages.cooldown-available", "&aCam-Modus wieder verf\u00fcgbar"));
-        camSafetyEnabled = getConfig().getBoolean("camSafetyEnabled", true);
-        camSafetyDelay = getConfig().getInt("camSafetyDelay", 5);
-        camSafetyMessage = getConfig().getString("camSafetyMessage",
+        camSafetyEnabled = getConfig().getBoolean("cam-safety.enabled", true);
+        camSafetyDelay = getConfig().getInt("cam-safety.delay", 5);
+        camSafetyMessage = getConfig().getString("messages.cam-safety",
                 "§cDu kannst den Cam-Modus nicht starten! Du musst noch %seconds% Sekunden in Sicherheit bleiben.");
         if (camFireGuard != null) {
             camFireGuard.loadConfig(getConfig());
@@ -1269,7 +1269,9 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         if (elapsed >= delayMillis) return true;
         long remaining = (delayMillis - elapsed + 999) / 1000;
         String msg = camSafetyMessage.replace("%seconds%", String.valueOf(remaining));
-        player.sendMessage(ChatColor.RED + ChatColor.translateAlternateColorCodes('&', msg));
+        if (isMessageEnabled("cam-safety")) {
+            player.sendMessage(ChatColor.RED + ChatColor.translateAlternateColorCodes('&', msg));
+        }
         return false;
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,7 @@ messages:
   cooldown-text: "Du kannst den Cam-Modus erst in %time% erneut starten."
   cooldown-available: "&aCam-Modus wieder verf\u00fcgbar"
   time-limit-expired: "&cCam-Modus beendet: Zeitbegrenzung abgelaufen."
+  cam-safety: "§cDu kannst den Cam-Modus nicht starten! Du musst noch %seconds% Sekunden in Sicherheit bleiben."
 
 message-settings:
   enabled: true
@@ -54,6 +55,7 @@ message-settings:
   cooldown-text: true
   cooldown-available: true
   time-limit-expired: true
+  cam-safety: true
 
 action-bar:
   enabled: true
@@ -70,16 +72,18 @@ camera-mode:
   allow_invisibility_potion: true
   allow_lava_flight: true
 
-armorstand.name-visible: true
-armorstand.visible: true
-armorstand.gravity: true
-armorstand.damage-amount: 1.0
-armorstand.durability-loss: true
-armorstand.damage-ignore-armor: true
+armorstand:
+  name-visible: true
+  visible: true
+  gravity: true
+  damage-amount: 1.0
+  durability-loss: true
+  damage-ignore-armor: true
 
-mute_attack: true
-mute_footsteps: true
-hide_sprint_particles: true
+mute:
+  attack: true
+  footsteps: true
+  hide-sprint-particles: true
 
 time-limit:
   enabled: false
@@ -100,8 +104,8 @@ fireguard:
   tick-interval: 10
   radius-horizontal: 1.5
   radius-up: 2
-radius-down: 1
+  radius-down: 1
 
-camSafetyEnabled: true
-camSafetyDelay: 5
-camSafetyMessage: "§cDu kannst den Cam-Modus nicht starten! Du musst noch %seconds% Sekunden in Sicherheit bleiben."
+cam-safety:
+  enabled: true
+  delay: 5

--- a/target/classes/config.yml
+++ b/target/classes/config.yml
@@ -27,6 +27,7 @@ messages:
   cooldown-text: "Du kannst den Cam-Modus erst in %time% erneut starten."
   cooldown-available: "&aCam-Modus wieder verf\u00fcgbar"
   time-limit-expired: "&cCam-Modus beendet: Zeitbegrenzung abgelaufen."
+  cam-safety: "§cDu kannst den Cam-Modus nicht starten! Du musst noch %seconds% Sekunden in Sicherheit bleiben."
 
 message-settings:
   enabled: true
@@ -54,6 +55,7 @@ message-settings:
   cooldown-text: true
   cooldown-available: true
   time-limit-expired: true
+  cam-safety: true
 
 action-bar:
   enabled: true
@@ -70,16 +72,18 @@ camera-mode:
   allow_invisibility_potion: true
   allow_lava_flight: true
 
-armorstand.name-visible: true
-armorstand.visible: true
-armorstand.gravity: true
-armorstand.damage-amount: 1.0
-armorstand.durability-loss: true
-armorstand.damage-ignore-armor: true
+armorstand:
+  name-visible: true
+  visible: true
+  gravity: true
+  damage-amount: 1.0
+  durability-loss: true
+  damage-ignore-armor: true
 
-mute_attack: true
-mute_footsteps: true
-hide_sprint_particles: true
+mute:
+  attack: true
+  footsteps: true
+  hide-sprint-particles: true
 
 time-limit:
   enabled: false
@@ -101,3 +105,7 @@ fireguard:
   radius-horizontal: 1.5
   radius-up: 2
   radius-down: 1
+
+cam-safety:
+  enabled: true
+  delay: 5


### PR DESCRIPTION
## Summary
- move camSafety settings under `cam-safety`
- allow toggling cam-safety message and place it under `messages`
- group mute and armorstand options into categories
- update plugin code for new config paths

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68748c28dcf48322a95c3edf7a2c98b3