### PR TITLE
Add optional camera head item

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -109,3 +109,6 @@ fireguard:
 cam-safety:
   enabled: true
   delay: 5
+
+camera-head:
+  enabled: false


### PR DESCRIPTION
## Summary
- add a new `camera-head.enabled` config option
- equip the player with a custom head if enabled
- implement helper to create the head item

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68759af03a788322a1cd66863c2dd792