### PR TITLE
Implement drowning and freeze immunity logic

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly2/CameraPlugin.java
@@ -659,6 +659,32 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
             return;
         }
 
+        // Custom immunities for the hitbox based on equipment
+        DamageCause cause = event.getCause();
+        CameraData data = cameraPlayers.get(ownerUUID);
+        if (cause == DamageCause.DROWNING && data != null) {
+            ItemStack[] armor = data.getOriginalArmorContents();
+            if (armor != null && armor.length > 3) {
+                ItemStack helmet = armor[3];
+                if (helmet != null && helmet.getType() == Material.TURTLE_HELMET) {
+                    if (damagedEntity instanceof LivingEntity living) {
+                        living.setRemainingAir(living.getMaximumAir());
+                    }
+                    pendingDamage.remove(ownerUUID);
+                    return;
+                }
+            }
+        }
+
+        if (cause == DamageCause.FREEZE && damagedEntity instanceof Villager villager) {
+            ItemStack boots = villager.getEquipment().getBoots();
+            if (boots != null && boots.getType() == Material.LEATHER_BOOTS) {
+                villager.setFreezeTicks(0);
+                pendingDamage.remove(ownerUUID);
+                return;
+            }
+        }
+
         String damagerName = "Umgebung";
         Entity damagerEntity = null;
         if (event instanceof EntityDamageByEntityEvent entityEvent) {


### PR DESCRIPTION
## Summary
- add special immunity logic for hitbox villager
- villager ignores drowning when the player wore a turtle helmet
- villager ignores freeze damage if wearing leather boots

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68781795646883228d8a5bda5cdfbfb1