### PR TITLE
Fix fire not hiding in camera mode

### DIFF
--- a/src/main/java/de/elia/cameraplugin/feuer/CamFireGuard.java
+++ b/src/main/java/de/elia/cameraplugin/feuer/CamFireGuard.java
@@ -123,7 +123,8 @@ public class CamFireGuard implements Listener {
         for (Block b : previous) if (!current.contains(b))
             p.sendBlockChange(b.getLocation(), b.getBlockData());
 
-        for (Block b : current) if (!previous.contains(b))
+        // Always resend the hide packet in case the client was updated by the server
+        for (Block b : current)
             p.sendBlockChange(b.getLocation(), Material.AIR.createBlockData());
 
         hiddenMap.put(p.getUniqueId(), current);


### PR DESCRIPTION
## Summary
- refresh hidden fire every tick so the server cannot overwrite the hidden block

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68784657f8488322be83cbc073431ce6