### PR TITLE
Fix bedrock players building

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: de.elia.cameraplugin.camfly2.CameraPlugin
 api-version: 1.21
 author: Rexminecraft343
 description: Ein Plugin für einen Kamera-Modus mit Rüstungsständer
-softdepend: [ProtocolLib]
+softdepend: [ProtocolLib, floodgate]
 
 commands:
   cam:


### PR DESCRIPTION
## Summary
- require Floodgate to check if player is from Bedrock edition
- prevent non-op Bedrock users from placing or breaking blocks

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68789afd1f988322b840931bb9cbc030